### PR TITLE
Support filtering by "groups" field, use seperators in the entry list, and cleaner ui

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -41,5 +41,6 @@
         </provider>
 	<meta-data android:name="com.sec.android.support.multiwindow" android:value="true" />
 	<meta-data android:name="android.max_aspect" android:value="10.0" />
+    <activity android:name=".GroupsActivity"/>
     </application>
 </manifest>

--- a/res/layout/bibtexentry.xml
+++ b/res/layout/bibtexentry.xml
@@ -8,6 +8,18 @@
 	      android:orientation="vertical"
 	      android:paddingTop="2sp"
 	      >
+	<TextView
+        android:id="@+id/separator"
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent"
+        android:gravity="left"
+        android:textSize="15sp"
+        android:textColor="#ffffff"
+        android:background="#808080"
+        android:textStyle="bold"
+        android:paddingLeft="3sp"
+        android:paddingTop="2sp"
+        android:paddingBottom="2sp"/>
   <TextView 
      android:id="@+id/bibtex_info"
      android:layout_width="fill_parent"    
@@ -38,7 +50,7 @@
      android:id="@+id/bibtex_journal"
      android:layout_width="fill_parent" 	    
      android:layout_height="wrap_content" 
-     android:textSize="12sp"
+     android:textSize="13sp"
      android:textColor="#505050"
      >
   </TextView>

--- a/res/layout/bibtexentry.xml
+++ b/res/layout/bibtexentry.xml
@@ -13,7 +13,7 @@
      android:layout_width="fill_parent"    
      android:layout_height="fill_parent"
      android:gravity="center"
-     android:textSize="20sp"
+     android:textSize="10sp"
      android:textColor="#808080"
      android:paddingTop="30sp"
      android:paddingBottom="30sp"
@@ -23,7 +23,7 @@
      android:id="@+id/bibtex_title"
      android:layout_width="fill_parent" 	    
      android:layout_height="wrap_content"
-     android:textSize="20sp" 
+     android:textSize="15sp"
      android:textStyle="bold"
      >
   </TextView>
@@ -31,14 +31,14 @@
      android:id="@+id/bibtex_authors"
      android:layout_width="fill_parent" 	    
      android:layout_height="wrap_content" 
-     android:textSize="18sp"
+     android:textSize="15sp"
      >
   </TextView>
   <TextView 
      android:id="@+id/bibtex_journal"
      android:layout_width="fill_parent" 	    
      android:layout_height="wrap_content" 
-     android:textSize="16sp"
+     android:textSize="12sp"
      android:textColor="#505050"
      >
   </TextView>

--- a/res/layout/bibtexentry.xml
+++ b/res/layout/bibtexentry.xml
@@ -42,22 +42,6 @@
      android:textColor="#505050"
      >
   </TextView>
-  <TextView
-     android:id="@+id/bibtex_doi"
-     android:layout_width="fill_parent" 	    
-     android:layout_height="wrap_content"
-     android:textSize="16sp"
-     android:textColor="#505050"
-     >
-  </TextView>
-  <TextView
-     android:id="@+id/bibtex_arxiv"
-     android:layout_width="fill_parent" 	    
-     android:layout_height="wrap_content"
-     android:textSize="16sp"
-     android:textColor="#505050"
-     >
-  </TextView>
   <!--  <TextView
 	android:id="@+id/bibtex_file"
 	android:layout_width="fill_parent" 	    

--- a/res/layout/bibtexlist.xml
+++ b/res/layout/bibtexlist.xml
@@ -1,4 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+	android:layout_width="fill_parent"
+	android:layout_height="wrap_content"
+	android:orientation="vertical">
+<TextView
+	android:id="@+id/group_titlebar"
+	android:layout_width="fill_parent"
+	android:layout_height="wrap_content"
+	android:visibility="gone"/>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
 		android:layout_width="fill_parent"
 		android:layout_height="fill_parent"	
@@ -26,4 +35,4 @@
 	  >
 </ListView>  
 </RelativeLayout>
-
+</LinearLayout>

--- a/res/layout/grouplistentry.xml
+++ b/res/layout/grouplistentry.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+  <TextView
+     android:id="@+id/group_name"
+     android:layout_width="fill_parent"
+     android:layout_height="fill_parent"
+     android:gravity="center"
+     android:textSize="20sp"
+     android:textColor="#808080"
+     />
+</LinearLayout>

--- a/res/layout/groupslist.xml
+++ b/res/layout/groupslist.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    >
+    <!--<ProgressBar style="?android:attr/progressBarStyleHorizontal"
+        android:id="@+id/progress_bar"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:indeterminate="true" />-->
+    <ListView android:id="@+id/bibtex_grouplist_view"
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent"
+        android:clickable="true"
+        android:saveEnabled="true"
+        android:focusableInTouchMode="true"
+        android:focusable="true"
+        android:fadeScrollbars="false"
+        >
+    </ListView>
+</RelativeLayout>

--- a/res/menu/main_menu.xml
+++ b/res/menu/main_menu.xml
@@ -30,6 +30,10 @@
 	      android:title="@string/menu_sort_by_journal"
 	      android:checkable="true"
 	      />
+	<item android:id="@+id/menu_sort_by_title"
+	      android:title="@string/menu_sort_by_title"
+	      android:checkable="true"
+	      />
       </menu>
     </item>
         <item

--- a/res/menu/main_menu.xml
+++ b/res/menu/main_menu.xml
@@ -32,6 +32,11 @@
 	      />
       </menu>
     </item>
+        <item
+          android:id="@+id/menu_groups"
+          android:title="@string/menu_groups"
+          app:showAsAction="never"
+          />
         <item android:id="@+id/menu_set_library_path"
 	  android:title="@string/menu_set_library_path" 
 	  android:showAsAction="never"

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -39,6 +39,7 @@
     <string name="menu_sort_by_date">Sort by date</string>
     <string name="menu_sort_by_author">Sort by author</string>
     <string name="menu_sort_by_journal">Sort by journal</string>
+    <string name="menu_sort_by_title">Sort by title</string>
     <string name="no_matches">No matches</string>
     <string name="pick_bibtex_library">Pick BibTeX file</string>
     <string name="exception_while_loading_library">Exception while loading the BibTeX library file: </string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -56,4 +56,5 @@
     <string name="dialog_analyse_library_root_message">Trying to find the requested file in the directory you picked. This might take a while because Android\'s DocumentFile.findFile() can be very slow... This only needs to be done while opening the first file.</string>
     <string name="dialog_analyse_library_root_message_success" formatted="false">Library found the file %s in %s under the uri %s.</string>
     <string name="dialog_analyse_library_root_message_failed" formatted="false">Library failed to find the file %s inside the directory %s.</string>
+    <string name="menu_groups">Groups</string>
 </resources>

--- a/src/com/cgogolin/library/BaseBibtexEntry.java
+++ b/src/com/cgogolin/library/BaseBibtexEntry.java
@@ -41,6 +41,20 @@ public class BaseBibtexEntry {
     public String getDocumentType() {
         return saveGet("documenttyp");
     }
+    public String getGroup() {
+        return saveGet("groups");
+    }
+    public List<String> getGroups(){
+        //We assume the following format:
+        //{group1, group2...}
+        if ( getGroup().equals("") ) return null;
+        String[] rawGroupString = getGroup().split(",");
+        for (int i = 0; i < rawGroupString.length; i++) {
+            rawGroupString[i] = rawGroupString[i].trim();
+        }
+        List<String> groups = new ArrayList<String>(Arrays.asList(rawGroupString));
+        return groups;
+    }
     public String getFile() {
         return saveGet("file");
     }

--- a/src/com/cgogolin/library/BibtexAdapter.java
+++ b/src/com/cgogolin/library/BibtexAdapter.java
@@ -319,8 +319,6 @@ public class BibtexAdapter extends BaseAdapter {
             setTextViewAppearance((TextView)convertView.findViewById(R.id.bibtex_title), "");
             setTextViewAppearance((TextView)convertView.findViewById(R.id.bibtex_authors), "");
             setTextViewAppearance((TextView)convertView.findViewById(R.id.bibtex_journal), "");
-            setTextViewAppearance((TextView)convertView.findViewById(R.id.bibtex_doi), "");
-            setTextViewAppearance((TextView)convertView.findViewById(R.id.bibtex_arxiv), "");
         }
         else
         {
@@ -328,8 +326,6 @@ public class BibtexAdapter extends BaseAdapter {
             setTextViewAppearance((TextView)convertView.findViewById(R.id.bibtex_title), entry.getTitle());
             setTextViewAppearance((TextView)convertView.findViewById(R.id.bibtex_authors), entry.getAuthorsFormated(context));
             setTextViewAppearance((TextView)convertView.findViewById(R.id.bibtex_journal), entry.getJournalFormated(context));
-            setTextViewAppearance((TextView)convertView.findViewById(R.id.bibtex_doi), entry.getDoiFormated(context));
-            setTextViewAppearance((TextView)convertView.findViewById(R.id.bibtex_arxiv), entry.getEprintFormated());
 
             if(entry.extraInfoVisible())
                 makeExtraInfoVisible(position, convertView, context, false);
@@ -393,6 +389,13 @@ public class BibtexAdapter extends BaseAdapter {
         entry.setExtraInfoVisible(true);
 
         LinearLayout.LayoutParams buttonLayoutParams = new LinearLayout.LayoutParams(LinearLayout.LayoutParams.FILL_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT);
+
+        final TextView doiTV = new TextView(context);
+        setTextViewAppearance(doiTV, entry.getDoiFormated(context));
+        extraInfo.addView(doiTV);
+        final TextView arxivTV = new TextView(context);
+        setTextViewAppearance(arxivTV, entry.getEprintFormated());
+        extraInfo.addView(arxivTV);
 
             //Read the Files list from the BibtexEntry
         List<String> associatedFilesList = entry.getFiles();

--- a/src/com/cgogolin/library/BibtexAdapter.java
+++ b/src/com/cgogolin/library/BibtexAdapter.java
@@ -58,7 +58,7 @@ import static java.util.Arrays.fill;
 
 public class BibtexAdapter extends BaseAdapter {
     
-    public enum SortMode {None, Date, Author, Journal}
+    public enum SortMode {None, Date, Author, Journal, Title}
     
     private ArrayList<BibtexEntry> bibtexEntryList;
     private ArrayList<BibtexEntry> displayedBibtexEntryList;
@@ -299,8 +299,21 @@ public class BibtexAdapter extends BaseAdapter {
                         return entry1.getJournal().toLowerCase().compareTo(entry2.getJournal().toLowerCase());
                     }
                 };
-
                 break;
+            case Title:
+                Collections.sort(displayedBibtexEntryList, new Comparator<BibtexEntry>() {
+                        @Override
+                        public int compare(BibtexEntry entry1, BibtexEntry entry2) {
+                            return  (entry1.getTitle()+entry1.getNumberInFile()).compareTo(entry2.getTitle()+entry2.getNumberInFile());
+                        }
+                    });
+                separatorComparator = new Comparator<BibtexEntry>() {
+                    @Override
+                    public int compare(BibtexEntry entry1, BibtexEntry entry2) {
+                        return entry1.getTitle().substring(0,1).compareTo(entry2.getTitle().substring(0,1));
+                    }
+                };
+
         }
         sortingAccordingTo = null;
         sortedAccordingTo = sortMode;
@@ -388,6 +401,9 @@ public class BibtexAdapter extends BaseAdapter {
                             break;
                         case Journal:
                             separatorText = entry.getJournal();
+                            break;
+                        case Title:
+                            separatorText = entry.getTitle().substring(0, 1);
                             break;
                     }
                 }

--- a/src/com/cgogolin/library/GroupsActivity.java
+++ b/src/com/cgogolin/library/GroupsActivity.java
@@ -1,0 +1,48 @@
+package com.cgogolin.library;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.support.v7.app.AppCompatActivity;
+import android.os.Bundle;
+import android.view.View;
+import android.widget.AdapterView;
+import android.widget.ArrayAdapter;
+import android.widget.ListView;
+
+import java.util.ArrayList;
+
+public class GroupsActivity extends AppCompatActivity {
+
+    private ArrayList<String> groupList = null;
+    private ArrayAdapter<String> groupsArrayAdapter = null;
+    private ListView lv = null;
+    private Context context;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        context = this;
+        setContentView(R.layout.groupslist);
+        groupList = (ArrayList<String>) getIntent().getSerializableExtra("group list");
+        groupList.add(0, "All");
+        groupsArrayAdapter = new ArrayAdapter<String> (this, R.layout.grouplistentry, R.id.group_name, groupList);
+        lv = (ListView) findViewById(R.id.bibtex_grouplist_view);
+        lv.setAdapter(groupsArrayAdapter);
+        lv.setOnItemClickListener(new AdapterView.OnItemClickListener(){
+            @Override
+            public void onItemClick(AdapterView<?>adapter, View v, int position, long id){
+                String selectedGroup = "";
+                if(position != 0) {
+                    selectedGroup = (String) adapter.getItemAtPosition(position);
+                }
+                Intent resultIntent = new Intent();
+                resultIntent.putExtra("group", selectedGroup);
+                setResult(Activity.RESULT_OK, resultIntent);
+                finish();
+            }
+        });
+
+    }
+
+}

--- a/src/com/cgogolin/library/Library.java
+++ b/src/com/cgogolin/library/Library.java
@@ -833,6 +833,9 @@ public class Library extends AppCompatActivity implements SearchView.OnQueryText
                     if(bibtexAdapter.getGroups().isEmpty() && menu != null){
                         menu.findItem(R.id.menu_groups).setVisible(false);
                     }
+                    if(!bibtexAdapter.getGroups().isEmpty() && menu != null){
+                        menu.findItem(R.id.menu_groups).setVisible(true);
+                    }
                 }
                 else
                 {

--- a/src/com/cgogolin/library/Library.java
+++ b/src/com/cgogolin/library/Library.java
@@ -148,7 +148,8 @@ public class Library extends AppCompatActivity implements SearchView.OnQueryText
     public static final int LIBRARY_FILE_PICK_REQUEST = 0;
     public static final int WRITE_PERMISSION_REQUEST = 1;
     public static final int SET_LIBRARY_FOLDER_ROOT_REQUEST = 2;
-    
+    public static final int SELECT_GROUP_REQUEST = 3;
+
     private boolean libraryWasPreviouslyInitializedCorrectly = false;
     private String libraryPathString = "/mnt/sdcard/";
     private String pathTargetString = "home/username";
@@ -164,7 +165,9 @@ public class Library extends AppCompatActivity implements SearchView.OnQueryText
     
     BibtexAdapter.SortMode sortMode = BibtexAdapter.SortMode.None;
     String filter = "";
-    
+    String group = "";
+    private Menu menu = null;
+
     private String oldQueryText = "";
     private String savedQueryText = null;
     private ListView bibtexListView = null;
@@ -228,7 +231,9 @@ public class Library extends AppCompatActivity implements SearchView.OnQueryText
             if(pathConversionMenuItem != null) 
                 pathConversionMenuItem.setVisible(false);
         }
-        
+
+        this.menu = menu;
+
         return true;
     }
 
@@ -260,6 +265,10 @@ public class Library extends AppCompatActivity implements SearchView.OnQueryText
                 sortMode = BibtexAdapter.SortMode.Journal;
                 sortInBackground(sortMode);
                 break;
+            case R.id.menu_groups:
+                Intent intent = new Intent(this, GroupsActivity.class);
+                intent.putExtra("group list", new ArrayList(bibtexAdapter.getGroups()));
+                startActivityForResult(intent, SELECT_GROUP_REQUEST);
             default:
                 return super.onOptionsItemSelected(item);
         }
@@ -298,7 +307,7 @@ public class Library extends AppCompatActivity implements SearchView.OnQueryText
     public void onNewIntent(Intent intent) { //Is called when a search is performed
         if (Intent.ACTION_SEARCH.equals(intent.getAction())) {
             filter = intent.getStringExtra(SearchManager.QUERY);
-            filterAndSortInBackground(filter, sortMode);
+            filterAndSortInBackground(filter, sortMode, group);
         }
             //Unocus the searchView and close the keyboard
         if(searchView != null)
@@ -811,8 +820,12 @@ public class Library extends AppCompatActivity implements SearchView.OnQueryText
                     bibtexAdapter.notifyDataSetChanged();
                     bibtexAdapter.onPostBackgroundOperation();
 
-                    filterAndSortInBackground(filter, sortMode);
+                    filterAndSortInBackground(filter, sortMode, group);
                     bibtexAdapter.prepareForFiltering();
+
+                    if(bibtexAdapter.getGroups().isEmpty() && menu != null){
+                        menu.findItem(R.id.menu_groups).setVisible(false);
+                    }
                 }
                 else
                 {
@@ -825,7 +838,8 @@ public class Library extends AppCompatActivity implements SearchView.OnQueryText
         
     private void resetFilter() {
         if(bibtexAdapter!=null)
-            bibtexAdapter.filterAndSortInBackground("", null);
+            bibtexAdapter.filterAndSortInBackground("", null, group);
+        filter = "";
     }
     
     private void sortInBackground(BibtexAdapter.SortMode sortMode) 
@@ -834,11 +848,11 @@ public class Library extends AppCompatActivity implements SearchView.OnQueryText
             bibtexAdapter.sortInBackground(sortMode);
     }
 
-    private void filterAndSortInBackground(String filter, BibtexAdapter.SortMode sortMode)
+    private void filterAndSortInBackground(String filter, BibtexAdapter.SortMode sortMode, String group)
     {
         if(bibtexAdapter!=null) 
         {
-            bibtexAdapter.filterAndSortInBackground(filter, sortMode);
+            bibtexAdapter.filterAndSortInBackground(filter, sortMode, group);
         }
     }
     
@@ -892,6 +906,22 @@ public class Library extends AppCompatActivity implements SearchView.OnQueryText
                     grantUriPermission(getPackageName(), treeUri, Intent.FLAG_GRANT_READ_URI_PERMISSION|Intent.FLAG_GRANT_WRITE_URI_PERMISSION);//Not sure this is necessary
                     getContentResolver().takePersistableUriPermission(treeUri, Intent.FLAG_GRANT_READ_URI_PERMISSION|Intent.FLAG_GRANT_WRITE_URI_PERMISSION );
                     analyseLibraryFolderRoot(treeUri);
+                }
+                break;
+            case SELECT_GROUP_REQUEST:
+                if(resultCode==Activity.RESULT_OK)
+                {
+                    group = intent.getStringExtra("group");
+                    filterAndSortInBackground(filter, sortMode, group);
+                    TextView group_titlebar = (TextView) findViewById(R.id.group_titlebar);
+
+                    if (bibtexAdapter.getGroups().contains(group)) {
+                        group_titlebar.setText(group);
+                        group_titlebar.setVisibility(View.VISIBLE);
+                    } else {
+                        group_titlebar.setText("");
+                        group_titlebar.setVisibility(View.GONE);
+                    }
                 }
         }
     }

--- a/src/com/cgogolin/library/Library.java
+++ b/src/com/cgogolin/library/Library.java
@@ -222,6 +222,9 @@ public class Library extends AppCompatActivity implements SearchView.OnQueryText
             case Journal:
                 SelectedSortMenuItem = menu.findItem(R.id.menu_sort_by_journal);
                 break;
+            case Title:
+                SelectedSortMenuItem = menu.findItem(R.id.menu_sort_by_title);
+                break;
         }
         if(SelectedSortMenuItem!=null)
             SelectedSortMenuItem.setChecked(true);
@@ -263,6 +266,10 @@ public class Library extends AppCompatActivity implements SearchView.OnQueryText
                 break;
             case R.id.menu_sort_by_journal:
                 sortMode = BibtexAdapter.SortMode.Journal;
+                sortInBackground(sortMode);
+                break;
+            case R.id.menu_sort_by_title:
+                sortMode = BibtexAdapter.SortMode.Title;
                 sortInBackground(sortMode);
                 break;
             case R.id.menu_groups:

--- a/src/com/cgogolin/library/Library.java
+++ b/src/com/cgogolin/library/Library.java
@@ -838,7 +838,7 @@ public class Library extends AppCompatActivity implements SearchView.OnQueryText
         
     private void resetFilter() {
         if(bibtexAdapter!=null)
-            bibtexAdapter.filterAndSortInBackground("", null, group);
+            bibtexAdapter.filterAndSortInBackground("", sortMode, group);
         filter = "";
     }
     


### PR DESCRIPTION
Hello cgogolin,
This is a really nice app, thank you!

To make it more useful for myself ,I added groups support based on the "groups" field created by JabRef, which I find very useful for large bibtex collections.
I also tweeked the ui a bit into what I think is a more efficient display of the entry list.
Changes:
1) Introduce a "groups" menu item, to display only entries of a specific group.
2) Move the arxiv and doi fields to the extra-info, as they clatter the list and are not useful as a visual cue when looking for an entry.
3) Use smaller fonts - it should probably be a user setting though.
4) Add separators to the sorted list - by letter, year, or journal, depending on the sort mode. Makes it easier to browse the list.
5) Add a sort-by-title mode.
6) Fix a small bug where clearing the filter returns an unsorted list.

If you find these useful, please consider merging these changes.

Thanks,
Niv